### PR TITLE
Update DCToolbox.psm1

### DIFF
--- a/DCToolbox/DCToolbox.psm1
+++ b/DCToolbox/DCToolbox.psm1
@@ -3413,7 +3413,7 @@ function Rename-DCConditionalAccessPolicies {
 
                 # Rename policy:
                 $params = @{
-                    DisplayName = "$($Policy.DisplayName -replace $PrefixFilter, $AddCustomPrefix))"
+                    DisplayName = "$($Policy.DisplayName -replace $PrefixFilter, $AddCustomPrefix)"
                 }
                 
                 Update-MgIdentityConditionalAccessPolicy -ConditionalAccessPolicyId $Policy.Id -BodyParameter $params


### PR DESCRIPTION
Renamed policies have extra ")" at the end after renaming.

e.g. 
PROD - CUSTOM - GRANT - Example)
PROD - GLOBAL - BLOCK - Countries not Allowed)