### PR TITLE
Removed -ExpandProperty "policy(`$expand=rules)"

### DIFF
--- a/DCToolbox/DCToolbox.psm1
+++ b/DCToolbox/DCToolbox.psm1
@@ -1633,7 +1633,7 @@ function Enable-DCEntraIDPIMRole {
         $CustomObject | Add-Member -MemberType NoteProperty -Name 'RoleDefinitionId' -Value $RoleAssignment.RoleDefinitionId
         $CustomObject | Add-Member -MemberType NoteProperty -Name 'DisplayName' -Value ($EntraIDRoleTemplates | Where-Object { $_.Id -eq $RoleAssignment.RoleDefinitionId } ).DisplayName
 
-        $PolicyAssignment = Get-MgPolicyRoleManagementPolicyAssignment -Filter "scopeId eq '/' and scopeType eq 'DirectoryRole' and roleDefinitionId eq '$($RoleAssignment.RoleDefinitionId)'" -ExpandProperty "policy(`$expand=rules)"
+        $PolicyAssignment = Get-MgPolicyRoleManagementPolicyAssignment -Filter "scopeId eq '/' and scopeType eq 'DirectoryRole' and roleDefinitionId eq '$($RoleAssignment.RoleDefinitionId)'"
 
         # Get the role management policy that's been assigned:
         $Policy = Get-MgPolicyRoleManagementPolicy -UnifiedRoleManagementPolicyId $PolicyAssignment.PolicyId


### PR DESCRIPTION
Removed ``-ExpandProperty "policy(`$expand=rules)"`` so that the script works again. This is solving issue #41 for me.

When I did some tests with the script, it turns out that the "Rules" property is empty and is therefore it returns the error specified in issue #41. Removing the `-ExpandProperty` parameter completely, solves this issue for me. I don't know if Microsoft have changed something as the script worked for me before, but stopped working all of a sudden.

After looking through the script a little bit more, I don't find any reason as to why the `-ExpandProperty` parameter should be needed, but it's possible that I have missed something as I'm not good at coding.