### PR TITLE
Fix bug where the Get-DCConditionalAccessPolicies requests read-write…

### DIFF
--- a/DCToolbox/DCToolbox.psm1
+++ b/DCToolbox/DCToolbox.psm1
@@ -3309,7 +3309,7 @@ function Get-DCConditionalAccessPolicies {
 
 
     # Connect to Microsoft Graph.
-    Connect-DCMsGraphAsUser -Scopes 'Policy.ReadWrite.ConditionalAccess', 'Policy.Read.All', 'Directory.Read.All' -Verbose
+    Connect-DCMsGraphAsUser -Scopes 'Policy.Read.ConditionalAccess', 'Policy.Read.All', 'Directory.Read.All' -Verbose
     
 
     # Get all existing policies.
@@ -3434,7 +3434,7 @@ function Remove-DCConditionalAccessPolicies {
 
 
     # Connect to Microsoft Graph.
-    Connect-DCMsGraphAsUser -Scopes 'Policy.Read.ConditionalAccess', 'Policy.Read.All', 'Directory.Read.All' -Verbose
+    Connect-DCMsGraphAsUser -Scopes 'Policy.ReadWrite.ConditionalAccess', 'Policy.Read.All', 'Directory.Read.All' -Verbose
 
 
     # Prompt for confirmation:


### PR DESCRIPTION
I am testing this module, and it looks very useful. I did find a glitch that the Get-DCConditionalAccessPolicies requested the  Policy.ReadWRITE.ConditionalAccess scope while the Remove-DCConditionalAccessPolicies scope requested the Policy.READ.ConditionalAccess scope. The two functions come right after each other, and I wonder if they were just flipflopped. I am proposing switching
Get-DCConditionalAccessPolicies: Request Policy.Read.ConditionalAccess
Remove-DCConditionalAccessPolicies: Request Policy.ReadWrite.ConditionalAccess.

Let me know any thoughts or reject if this is a misunderstanding. Thank you!